### PR TITLE
disable aluvm log feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ amplify = "4.6.0"
 ascii-armor = "0.2.0"
 strict_encoding = "2.7.0-beta.1"
 strict_types = "2.7.0-beta.2"
-aluvm = { version = "0.11.0-beta.4", features = ["log"] }
+aluvm = "0.11.0-beta.4"
 bp-core = "0.11.0-beta.4"
 rgb-std = { version = "0.11.0-beta.4", features = ["serde", "fs"] }
 serde = "1.0"
@@ -29,7 +29,8 @@ chrono = "0.4.31"
 serde_yaml = "0.9.27"
 
 [features]
-all = []
+all = ["log"]
+log = ["aluvm/log"]
 
 [patch.crates-io]
 commit_verify = { git = "https://github.com/LNP-BP/client_side_validation", branch = "master" }


### PR DESCRIPTION
This PR disables `aluvm`'s `log` feature (ref. https://github.com/AluVM/rust-aluvm/issues/101) to prevent verbose messages being printed.