### PR TITLE
add deterministic_contract_id test

### DIFF
--- a/src/nia.rs
+++ b/src/nia.rs
@@ -182,6 +182,17 @@ impl IssuerWrapper for NonInflatableAsset {
 
 #[cfg(test)]
 mod test {
+    use std::str::FromStr;
+
+    use bp::seals::txout::{BlindSeal, CloseMethod};
+    use bp::Txid;
+    use chrono::DateTime;
+    use rgbstd::containers::BuilderSeal;
+    use rgbstd::interface::*;
+    use rgbstd::invoice::Precision;
+    use rgbstd::stl::*;
+    use rgbstd::*;
+
     use super::*;
 
     #[test]
@@ -193,5 +204,71 @@ mod test {
             }
             panic!("invalid NIA RGB20 interface implementation");
         }
+    }
+
+    #[test]
+    fn deterministic_contract_id() {
+        let created_at = 1713261744;
+        let terms = ContractTerms {
+            text: RicardianContract::default(),
+            media: None,
+        };
+        let spec = AssetSpec {
+            ticker: Ticker::from("TICKER"),
+            name: Name::from("NAME"),
+            details: None,
+            precision: Precision::try_from(2).unwrap(),
+        };
+        let issued_supply = 999u64;
+        let seal: XChain<BlindSeal<Txid>> = XChain::with(
+            Layer1::Bitcoin,
+            GenesisSeal::from(BlindSeal::with_blinding(
+                CloseMethod::OpretFirst,
+                Txid::from_str("8d54c98d4c29a1ec4fd90635f543f0f7a871a78eb6a6e706342f831d92e3ba19")
+                    .unwrap(),
+                0,
+                654321,
+            )),
+        );
+        let asset_tag = AssetTag::new_deterministic(
+            "contract_domain",
+            AssignmentType::with(0),
+            DateTime::from_timestamp(created_at, 0).unwrap(),
+            123456,
+        );
+
+        let builder = ContractBuilder::deterministic(
+            Identity::default(),
+            Rgb20::iface(rgb20::Features::FIXED),
+            NonInflatableAsset::schema(),
+            NonInflatableAsset::issue_impl(),
+            NonInflatableAsset::types(),
+            NonInflatableAsset::scripts(),
+        )
+        .add_global_state("spec", spec)
+        .unwrap()
+        .add_global_state("terms", terms)
+        .unwrap()
+        .add_global_state("issuedSupply", Amount::from(issued_supply))
+        .unwrap()
+        .add_asset_tag("assetOwner", asset_tag)
+        .unwrap()
+        .add_fungible_state_det(
+            "assetOwner",
+            BuilderSeal::from(seal),
+            issued_supply,
+            BlindingFactor::from_str(
+                "a3401bcceb26201b55978ff705fecf7d8a0a03598ebeccf2a947030b91a0ff53",
+            )
+            .unwrap(),
+        )
+        .unwrap();
+
+        let contract = builder.issue_contract_det(created_at).unwrap();
+
+        assert_eq!(
+            contract.contract_id().to_string(),
+            s!("rgb:qFuT6DN8-9AuO95M-7R8R8Mc-AZvs7zG-obum1Va-BRnweKk")
+        );
     }
 }


### PR DESCRIPTION
This PR adds a test to assert the deterministic contract ID feature works.

~~It requires https://github.com/RGB-WG/rgb-std/pull/190 to be merged first, after that I'll update the URL of the patched crate.~~